### PR TITLE
Add STUNNEL for SSL Proxy Support for Onocoy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,4 +80,4 @@ RUN mkdir -p /etc/stunnel && \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost"
 
 # Start stunnel and the main application
-CMD ["sh", "-c", "stunnel /etc/stunnel/stunnel.conf && /app/docker-init.sh"]
+CMD ["/app/docker-init.sh"]

--- a/docker-init.sh
+++ b/docker-init.sh
@@ -66,12 +66,20 @@ run_onocoy_server() {
             sleep 1
             echo "ONOCOY_MOUNTPOINT: $ONOCOY_MOUNTPOINT"
             echo "STARTING NTRIPSERVER ONOCOY NTRIPv2 SERVER...."
-            run_and_retry stunnel /etc/stunnel/stunnel.conf &
-            run_and_retry ntripserver -M 2 -H "127.0.0.1" -P "${TCP_OUTPUT_PORT}" -O 1 -a "127.0.0.1" -p "2101" -m "$ONOCOY_MOUNTPOINT" -n "$ONOCOY_USERNAME" -c "$ONOCOY_PASSWORD" &
+            if [ "$ONOCOY_USE_SSL" = true ]; then
+                run_and_retry stunnel /etc/stunnel/stunnel.conf &
+                run_and_retry ntripserver -M 2 -H "127.0.0.1" -P "${TCP_OUTPUT_PORT}" -O 1 -a "127.0.0.1" -p "2101" -m "$ONOCOY_MOUNTPOINT" -n "$ONOCOY_USERNAME" -c "$ONOCOY_PASSWORD" &
+            else
+                run_and_retry ntripserver -M 2 -H "127.0.0.1" -P "${TCP_OUTPUT_PORT}" -O 1 -a "servers.onocoy.com" -p "2101" -m "$ONOCOY_MOUNTPOINT" -n "$ONOCOY_USERNAME" -c "$ONOCOY_PASSWORD" &
+            fi
         else
             echo "STARTING RTKLIB ONOCOY NTRIPv1 SERVER...."
-            run_and_retry stunnel /etc/stunnel/stunnel.conf &
-            run_and_retry str2str -in "tcpcli://127.0.0.1:${TCP_OUTPUT_PORT}#rtcm3" -out "ntrips://:${ONOCOY_PASSWORD}@127.0.0.1:2101/${ONOCOY_USERNAME}#rtcm3" -msg "$RTCM_MSGS" $LAT_LONG_ELEVATION $INSTRUMENT $ANTENNA -t 0 &
+            if [ "$ONOCOY_USE_SSL" = true ]; then
+                run_and_retry stunnel /etc/stunnel/stunnel.conf &
+                run_and_retry str2str -in "tcpcli://127.0.0.1:${TCP_OUTPUT_PORT}#rtcm3" -out "ntrips://:${ONOCOY_PASSWORD}@127.0.0.1:2101/${ONOCOY_USERNAME}#rtcm3" -msg "$RTCM_MSGS" $LAT_LONG_ELEVATION $INSTRUMENT $ANTENNA -t 0 &
+            else
+                run_and_retry str2str -in "tcpcli://127.0.0.1:${TCP_OUTPUT_PORT}#rtcm3" -out "ntrips://:${ONOCOY_PASSWORD}@servers.onocoy.com:2101/${ONOCOY_USERNAME}#rtcm3" -msg "$RTCM_MSGS" $LAT_LONG_ELEVATION $INSTRUMENT $ANTENNA -t 0 &
+            fi
         fi
     fi
 }

--- a/docker-init.sh
+++ b/docker-init.sh
@@ -66,10 +66,12 @@ run_onocoy_server() {
             sleep 1
             echo "ONOCOY_MOUNTPOINT: $ONOCOY_MOUNTPOINT"
             echo "STARTING NTRIPSERVER ONOCOY NTRIPv2 SERVER...."
-            run_and_retry ntripserver -M 2 -H "127.0.0.1" -P "${TCP_OUTPUT_PORT}" -O 1 -a "servers.onocoy.com" -p "2101" -m "$ONOCOY_MOUNTPOINT" -n "$ONOCOY_USERNAME" -c "$ONOCOY_PASSWORD" &
+            run_and_retry stunnel /etc/stunnel/stunnel.conf &
+            run_and_retry ntripserver -M 2 -H "127.0.0.1" -P "${TCP_OUTPUT_PORT}" -O 1 -a "127.0.0.1" -p "2101" -m "$ONOCOY_MOUNTPOINT" -n "$ONOCOY_USERNAME" -c "$ONOCOY_PASSWORD" &
         else
             echo "STARTING RTKLIB ONOCOY NTRIPv1 SERVER...."
-            run_and_retry str2str -in "tcpcli://127.0.0.1:${TCP_OUTPUT_PORT}#rtcm3" -out "ntrips://:${ONOCOY_PASSWORD}@servers.onocoy.com:2101/${ONOCOY_USERNAME}#rtcm3" -msg "$RTCM_MSGS" $LAT_LONG_ELEVATION $INSTRUMENT $ANTENNA -t 0 &
+            run_and_retry stunnel /etc/stunnel/stunnel.conf &
+            run_and_retry str2str -in "tcpcli://127.0.0.1:${TCP_OUTPUT_PORT}#rtcm3" -out "ntrips://:${ONOCOY_PASSWORD}@127.0.0.1:2101/${ONOCOY_USERNAME}#rtcm3" -msg "$RTCM_MSGS" $LAT_LONG_ELEVATION $INSTRUMENT $ANTENNA -t 0 &
         fi
     fi
 }

--- a/stunnel.conf
+++ b/stunnel.conf
@@ -1,0 +1,14 @@
+# stunnel configuration file for SSL proxying
+
+# Debug level (0..7)
+debug = 7
+
+# Use it for client mode
+client = yes
+
+# Service-level configuration
+
+[ntrip]
+accept = 2101
+connect = servers.onocoy.com:2121
+verify = 0


### PR DESCRIPTION
### Description

This pull request introduces the use of `stunnel` to provide SSL proxy support for Onocoy. The changes allow the `str2str` and `ntripserver` commands to run with or without SSL, based on the `ONOCOY_USE_SSL` flag.

### Changes Made

1. **Conditional Execution Based on `ONOCOY_USE_SSL` Flag:**
    - When `ONOCOY_USE_SSL` is set to `true`, the script will run `stunnel` and configure `str2str` to communicate via localhost.
    - When `ONOCOY_USE_SSL` is set to `false`, the script will configure `str2str` to communicate directly with the external Onocoy server.

2. **Updated Health Check Script:**
    - Added logic to verify that exactly one instance of `stunnel` is running when `ONOCOY_USE_SSL` is enabled.
    - Updated the checks for `ntripserver` and `str2str` to accommodate the new conditional logic.