### PR TITLE
Fix incorrect echo statement for ONOCOY_PASSWORD in run_onocoy_server function

### DIFF
--- a/docker-init.sh
+++ b/docker-init.sh
@@ -62,7 +62,7 @@ run_onocoy_server() {
         ONOCOY_PASSWORD=$PASSWORD
     fi
     if [ -n "$ONOCOY_PASSWORD" ] && [ -n "$ONOCOY_USERNAME" ]; then
-        echo "ONOCOY_USERNAME: $ONOCOY_PASSWORD"
+        echo "ONOCOY_PASSWORD: $ONOCOY_PASSWORD"
         echo "ONOCOY_USERNAME: $ONOCOY_USERNAME"
         if [ -n "$ONOCOY_MOUNTPOINT" ] || [ "$ONOCOY_USE_NTRIPSERVER" = true ]; then
             sleep 1


### PR DESCRIPTION
This PR addresses a small issue in the run_onocoy_server function where the echo statement incorrectly prints the ONOCOY_USERNAME twice. The first echo statement has been updated to correctly print ONOCOY_PASSWORD instead of duplicating ONOCOY_USERNAME.